### PR TITLE
Fix param order on CreateItemRequestBuilder constructor

### DIFF
--- a/src/main/scala/com/github/filosganga/play/predictionio/Api.scala
+++ b/src/main/scala/com/github/filosganga/play/predictionio/Api.scala
@@ -88,7 +88,7 @@ trait Api {
     withClient {
       client =>
 
-        val request = client.getUserActionItemRequestBuilder(userId, itemId, action).t(dateTime)
+        val request = client.getUserActionItemRequestBuilder(userId, action, itemId).t(dateTime)
         rate.foreach(request.rate)
         location.foreach(l => request.longitude(l.longitude).latitude(l.latitude))
 

--- a/src/main/scala/com/github/filosganga/play/predictionio/Api.scala
+++ b/src/main/scala/com/github/filosganga/play/predictionio/Api.scala
@@ -123,7 +123,31 @@ trait Api {
       case (id, atts) => ItemInfo(id, attributes.toSet)
     }
   }
+  def getItemsRecTopNM(engine: String,
+                      userId: String,
+                      n: Int = 15,
+                      types: Set[String] = Set.empty,
+                      attributes: Set[String] = Set.empty,
+                      location: Option[Location] = None,
+                      distance: Option[Distance] = None)(implicit ec: ExecutionContext): Future[Map[String,Set[String]]] = future {
 
+    withClient {
+      client =>
+
+        val rb = client.getItemRecGetTopNRequestBuilder(engine, userId, n)
+        rb.attributes(attributes.toArray)
+        rb.itypes(types.toArray)
+
+        location.foreach(l => rb.latitude(l.latitude).longitude(l.longitude))
+        distance.foreach {
+          case Km(x) => rb.unit("km").within(x)
+          case Mi(x) => rb.unit("mi").within(x)
+        }
+
+        client.getItemRecTopNWithAttributes(rb)
+
+    }.toMap.mapValues(_.toSet)
+  }
   def getItemsSimTopN(engine: String,
                       targetId: String,
                       n: Int = 15,

--- a/src/main/scala/com/github/filosganga/play/predictionio/PredictionIO.scala
+++ b/src/main/scala/com/github/filosganga/play/predictionio/PredictionIO.scala
@@ -89,6 +89,17 @@ object PredictionIO {
     api.getItemsRecTopN(engine, userId, n, types, attributes, location, distance)
   }
 
+  def getItemsInfoRecTopNM(engine: String,
+                          userId: String,
+                          n: Int = 15,
+                          types: Set[String] = Set.empty,
+                          attributes: Set[String] = Set.empty,
+                          location: Option[Location],
+                          distance: Option[Distance])(implicit app: Application, ec: ExecutionContext): Future[Map[String,Set[String]]] = {
+
+    api.getItemsRecTopNM(engine, userId, n, types, attributes, location, distance)
+  }
+
   def getItemsInfoSimTopN(engine: String,
                           targetId: String,
                           n: Int = 15,

--- a/src/test/scala/com/github/filosganga/play/predictionio/ApiSpec.scala
+++ b/src/test/scala/com/github/filosganga/play/predictionio/ApiSpec.scala
@@ -188,7 +188,7 @@ class ApiSpec extends Specification with Mockito {
 
         Await.ready(toTest.userActionItem("1", "2", "like"), Duration.Inf)
 
-        there was one(client).getUserActionItemRequestBuilder(===("1"), ===("2"), ===("like"))
+        there was one(client).getUserActionItemRequestBuilder(===("1"), ===("like"), ===("2"))
       }
       "with given rate" in new SpecsScope {
 


### PR DESCRIPTION
The underlying client expects userId, action, itemId instead of userId, itemId,
action.

The current version leads to getting an error from prediction.io about pio_action not supporting custom actions yet.
