### PR TITLE
Introduce types for UserID, ItemId and U2IAction

### DIFF
--- a/src/main/scala/com/github/filosganga/play/predictionio/Api.scala
+++ b/src/main/scala/com/github/filosganga/play/predictionio/Api.scala
@@ -15,7 +15,7 @@ trait Api {
 
   lazy val format = new JsonFormat(apiKey)
 
-  def getUser(id: String)(implicit ec: ExecutionContext): Future[User] = {
+  def getUser(id: UserId)(implicit ec: ExecutionContext): Future[User] = {
 
     import format._
 
@@ -39,14 +39,14 @@ trait Api {
     }
   }
 
-  def deleteUser(uid: String)(implicit ec: ExecutionContext): Future[Unit] = {
+  def deleteUser(uid: UserId)(implicit ec: ExecutionContext): Future[Unit] = {
     WS.url(s"$endpoint/users/$uid.json").withQueryString("pio_appkey" -> apiKey).delete().map {
       case response if response.status >= 300 => Future.failed(new RuntimeException(response.statusText))
       case _ => Future.successful()
     }
   }
 
-  def getItem(id: String)(implicit ec: ExecutionContext): Future[Item] = {
+  def getItem(id: ItemId)(implicit ec: ExecutionContext): Future[Item] = {
 
     import format._
 
@@ -68,7 +68,7 @@ trait Api {
     }
   }
 
-  def deleteItem(id: String)(implicit ec: ExecutionContext): Future[Unit] = future {
+  def deleteItem(id: ItemId)(implicit ec: ExecutionContext): Future[Unit] = future {
     WS.url(s"$endpoint/items/$id.json").withQueryString("pio_appkey" -> apiKey).delete().flatMap {
       case response if response.status >= 300 => Future.failed(new RuntimeException(response.statusText))
       case _ => Future.successful()
@@ -86,7 +86,7 @@ trait Api {
   }
 
   def getItemsRecTopN(engine: String,
-                      userId: String,
+                      userId: UserId,
                       n: Int = 15,
                       types: Set[String] = Set.empty,
                       attributes: Set[String] = Set.empty,
@@ -98,7 +98,7 @@ trait Api {
 
     val parameters = Seq(
       "pio_appkey" -> apiKey,
-      "pio_uid" -> userId,
+      "pio_uid" -> userId.value,
       "pio_n" -> s"$n"
     ) ++
       (if (types.nonEmpty) Seq("pio_itypes" -> types.mkString(",")) else Nil) ++
@@ -117,7 +117,7 @@ trait Api {
   }
 
   def getItemsSimTopN(engine: String,
-                      targetId: String,
+                      targetId: ItemId,
                       n: Int = 15,
                       types: Set[String] = Set.empty,
                       attributes: Set[String] = Set.empty,
@@ -129,7 +129,7 @@ trait Api {
 
     val parameters = Seq(
       "pio_appkey" -> apiKey,
-      "pio_iid" -> targetId,
+      "pio_iid" -> targetId.value,
       "pio_n" -> s"$n"
     ) ++
       (if (types.nonEmpty) Seq("pio_itypes" -> types.mkString(",")) else Nil) ++

--- a/src/main/scala/com/github/filosganga/play/predictionio/PredictionIO.scala
+++ b/src/main/scala/com/github/filosganga/play/predictionio/PredictionIO.scala
@@ -36,7 +36,7 @@ object PredictionIO {
   private def api(implicit app: Application): Api =
     app.plugin[HasApi].getOrElse(throw pluginNotRegisteredError).api
 
-  def createUser(uid: String,
+  def createUser(uid: UserId,
                  active: Boolean = true,
                  location: Option[Location] = None,
                  customs: Map[String, String] = Map.empty)
@@ -48,15 +48,15 @@ object PredictionIO {
     api.createUser(user)
   }
 
-  def getUser(uid: String)(implicit app: Application, ec: ExecutionContext): Future[User] = {
+  def getUser(uid: UserId)(implicit app: Application, ec: ExecutionContext): Future[User] = {
     api.getUser(uid)
   }
 
-  def deleteUser(uid: String)(implicit app: Application, ec: ExecutionContext): Future[Unit] = {
+  def deleteUser(uid: UserId)(implicit app: Application, ec: ExecutionContext): Future[Unit] = {
     api.deleteUser(uid)
   }
 
-  def createItem(id: String,
+  def createItem(id: ItemId,
                  types: Set[String],
                  active: Boolean = true,
                  location: Option[Location] = None,
@@ -73,16 +73,16 @@ object PredictionIO {
     api.createItem(item)
   }
 
-  def getItem(id: String)(implicit app: Application, ec: ExecutionContext): Future[Item] =
+  def getItem(id: ItemId)(implicit app: Application, ec: ExecutionContext): Future[Item] =
     api.getItem(id)
 
-  def deleteItem(id: String)(implicit app: Application, ec: ExecutionContext): Future[Unit] = {
+  def deleteItem(id: ItemId)(implicit app: Application, ec: ExecutionContext): Future[Unit] = {
     api.deleteItem(id)
   }
 
-  def userActionItem(userId: String,
-                     itemId: String,
-                     action: String,
+  def userActionItem(userId: UserId,
+                     itemId: ItemId,
+                     action: U2IAction,
                      rate: Option[Int] = None,
                      dateTime: Option[DateTime] = None,
                      location: Option[Location] = None,
@@ -97,7 +97,7 @@ object PredictionIO {
   }
 
   def getItemsInfoRecTopN(engine: String,
-                          userId: String,
+                          userId: UserId,
                           n: Int = 15,
                           types: Set[String] = Set.empty,
                           attributes: Set[String] = Set.empty,
@@ -108,7 +108,7 @@ object PredictionIO {
   }
 
   def getItemsInfoSimTopN(engine: String,
-                          targetId: String,
+                          targetId: ItemId,
                           n: Int = 15,
                           types: Set[String] = Set.empty,
                           attributes: Set[String] = Set.empty,
@@ -119,7 +119,7 @@ object PredictionIO {
   }
 
   def getItemsRecTopN(engine: String,
-                      userId: String,
+                      userId: UserId,
                       n: Int = 15,
                       types: Set[String] = Set.empty,
                       attributes: Set[String] = Set.empty,
@@ -127,12 +127,12 @@ object PredictionIO {
                       distance: Option[Distance])(implicit app: Application, ec: ExecutionContext): Future[Iterable[Item]] = {
 
     getItemsInfoRecTopN(engine, userId, n, types, attributes, location, distance).flatMap {
-      xs => Future.sequence(xs.map(x => getItem(x.id)))
+      xs => Future.sequence(xs.map(x => getItem(ItemId(x.id))))
     }
   }
 
   def getItemsSimTopN(engine: String,
-                      targetId: String,
+                      targetId: ItemId,
                       n: Int = 15,
                       types: Set[String] = Set.empty,
                       attributes: Set[String] = Set.empty,
@@ -140,7 +140,7 @@ object PredictionIO {
                       distance: Option[Distance])(implicit app: Application, ec: ExecutionContext): Future[Iterable[Item]] = {
 
     getItemsInfoSimTopN(engine, targetId, n, types, attributes, location, distance).flatMap {
-      xs => Future.sequence(xs.map(x => getItem(x.id)))
+      xs => Future.sequence(xs.map(x => getItem(ItemId(x.id))))
     }
   }
 

--- a/src/main/scala/com/github/filosganga/play/predictionio/domain.scala
+++ b/src/main/scala/com/github/filosganga/play/predictionio/domain.scala
@@ -21,13 +21,25 @@ import org.joda.time.DateTime
  * under the License.
  */
 
+case class UserId(value:String) extends AnyVal
+case class ItemId(value:String) extends AnyVal
+sealed trait U2IAction
+case object U2IAction {
+  case object Like extends U2IAction
+  case object Dislike extends U2IAction
+  case object Rate extends U2IAction
+  case object View extends U2IAction
+  case object ViewDetails extends U2IAction
+  case object Conversion extends U2IAction
+}
 
-case class User(uid: String,
+
+case class User(uid: UserId,
                 active: Boolean = true,
                 location: Option[Location] = None,
                 customs: Map[String, String] = Map.empty)
 
-case class Item(iid: String,
+case class Item(iid: ItemId,
                 types: Set[String] = Set.empty,
                 active: Boolean = true,
                 location: Option[Location] = None,
@@ -37,9 +49,9 @@ case class Item(iid: String,
                 profit: Option[Double] = None,
                 customs: Map[String, String] = Map.empty)
 
-case class Action(userId: String,
-                  itemId: String,
-                  action: String,
+case class Action(userId: UserId,
+                  itemId: ItemId,
+                  action: U2IAction,
                   rate: Option[Int] = None,
                   location: Option[Location] = None,
                   time: Option[DateTime] = None,

--- a/src/test/scala/com/github/filosganga/play/predictionio/JsonFormatSpec.scala
+++ b/src/test/scala/com/github/filosganga/play/predictionio/JsonFormatSpec.scala
@@ -44,7 +44,7 @@ class JsonFormatSpec extends Specification {
             | }
           """.stripMargin)).get
 
-        user should be equalTo User("test")
+        user should be equalTo User(UserId("test"))
       }
 
       "with active" in new ThisScope {
@@ -59,7 +59,7 @@ class JsonFormatSpec extends Specification {
             | }
           """.stripMargin)).get
 
-        user should be equalTo User("test", active = false)
+        user should be equalTo User(UserId("test"), active = false)
       }
 
 
@@ -75,7 +75,7 @@ class JsonFormatSpec extends Specification {
             | }
           """.stripMargin)).get
 
-        user should be equalTo User("test", location = Some(Location(12.34, 5.67)))
+        user should be equalTo User(UserId("test"), location = Some(Location(12.34, 5.67)))
       }
 
       "with customs" in new ThisScope {
@@ -91,7 +91,7 @@ class JsonFormatSpec extends Specification {
             | }
           """.stripMargin)).get
 
-        user should be equalTo User("test", customs = Map("foo"->"bar", "aaa"->"bbb"))
+        user should be equalTo User(UserId("test"), customs = Map("foo"->"bar", "aaa"->"bbb"))
       }
 
       "with all fields" in new ThisScope {
@@ -109,7 +109,7 @@ class JsonFormatSpec extends Specification {
             | }
           """.stripMargin)).get
 
-        user should be equalTo User("test", active = false, location = Some(Location(12.34, 5.67)), customs = Map("foo"->"bar", "aaa"->"bbb"))
+        user should be equalTo User(UserId("test"), active = false, location = Some(Location(12.34, 5.67)), customs = Map("foo"->"bar", "aaa"->"bbb"))
       }
     }
   }
@@ -121,7 +121,7 @@ class JsonFormatSpec extends Specification {
 
         import jsonFormat._
 
-        val json = Json.toJson(User("test"))
+        val json = Json.toJson(User(UserId("test")))
 
         (json \ "pio_appkey").validate[String] should be equalTo JsSuccess(appKey)
         (json \ "pio_uid").validate[String] should be equalTo JsSuccess("test")
@@ -131,7 +131,7 @@ class JsonFormatSpec extends Specification {
 
         import jsonFormat._
 
-        val json = Json.toJson(User("test", active = false))
+        val json = Json.toJson(User(UserId("test"), active = false))
 
         (json \ "pio_appkey").validate[String] should be equalTo JsSuccess(appKey)
         (json \ "pio_uid").validate[String] should be equalTo JsSuccess("test")
@@ -142,7 +142,7 @@ class JsonFormatSpec extends Specification {
 
         import jsonFormat._
 
-        val json = Json.toJson(User("test", location = Some(Location(9.4, 3.4))))
+        val json = Json.toJson(User(UserId("test"), location = Some(Location(9.4, 3.4))))
 
         (json \ "pio_appkey").validate[String] should be equalTo JsSuccess(appKey)
         (json \ "pio_uid").validate[String] should be equalTo JsSuccess("test")
@@ -153,7 +153,7 @@ class JsonFormatSpec extends Specification {
 
         import jsonFormat._
 
-        val json = Json.toJson(User("test", customs = Map("foo"->"Bar")))
+        val json = Json.toJson(User(UserId("test"), customs = Map("foo"->"Bar")))
 
         (json \ "pio_appkey").validate[String] should be equalTo JsSuccess(appKey)
         (json \ "pio_uid").validate[String] should be equalTo JsSuccess("test")
@@ -164,7 +164,7 @@ class JsonFormatSpec extends Specification {
 
         import jsonFormat._
 
-        val json = Json.toJson(User("test", active = false, location = Some(Location(12.3, 45.6)), customs = Map("foo"->"Bar")))
+        val json = Json.toJson(User(UserId("test"), active = false, location = Some(Location(12.3, 45.6)), customs = Map("foo"->"Bar")))
 
         (json \ "pio_appkey").validate[String] should be equalTo JsSuccess(appKey)
         (json \ "pio_uid").validate[String] should be equalTo JsSuccess("test")
@@ -192,7 +192,7 @@ class JsonFormatSpec extends Specification {
             valid => valid
           )
 
-        item should be equalTo Item("test")
+        item should be equalTo Item(ItemId("test"))
       }
 
       "with active" in new ThisScope {
@@ -210,7 +210,7 @@ class JsonFormatSpec extends Specification {
           valid => valid
         )
 
-        item should be equalTo Item("test", active = false)
+        item should be equalTo Item(ItemId("test"), active = false)
       }
 
       "with types" in new ThisScope {
@@ -227,7 +227,7 @@ class JsonFormatSpec extends Specification {
             invalid => throw new RuntimeException(invalid.mkString(",")),
             valid => valid
           )
-        item should be equalTo Item("test", types = Set("one", "two", "three"))
+        item should be equalTo Item(ItemId("test"), types = Set("one", "two", "three"))
       }
 
 
@@ -245,7 +245,7 @@ class JsonFormatSpec extends Specification {
             invalid => throw new RuntimeException(invalid.mkString(",")),
             valid => valid
           )
-        item should be equalTo Item("test", location = Some(Location(12.34, 5.67)))
+        item should be equalTo Item(ItemId("test"), location = Some(Location(12.34, 5.67)))
       }
 
       "with price" in new ThisScope {
@@ -262,7 +262,7 @@ class JsonFormatSpec extends Specification {
             invalid => throw new RuntimeException(invalid.mkString(",")),
             valid => valid
           )
-        item should be equalTo Item("test", price = Some(123.67))
+        item should be equalTo Item(ItemId("test"), price = Some(123.67))
       }
 
       "with profit" in new ThisScope {
@@ -280,7 +280,7 @@ class JsonFormatSpec extends Specification {
             valid => valid
           )
 
-        item should be equalTo Item("test", profit = Some(123.67))
+        item should be equalTo Item(ItemId("test"), profit = Some(123.67))
       }
 
       "with start time" in new ThisScope {
@@ -298,7 +298,7 @@ class JsonFormatSpec extends Specification {
             valid => valid
           )
 
-        item should be equalTo Item("test", startTime = Some(new DateTime(123456789L)))
+        item should be equalTo Item(ItemId("test"), startTime = Some(new DateTime(123456789L)))
       }
 
       "with end time" in new ThisScope {
@@ -316,7 +316,7 @@ class JsonFormatSpec extends Specification {
             valid => valid
           )
 
-        item should be equalTo Item("test", endTime = Some(new DateTime(123456790L)))
+        item should be equalTo Item(ItemId("test"), endTime = Some(new DateTime(123456790L)))
       }
 
       "with customs" in new ThisScope {
@@ -335,7 +335,7 @@ class JsonFormatSpec extends Specification {
             valid => valid
           )
 
-        item should be equalTo Item("test", customs = Map("foo"->"bar", "aaa"->"bbb"))
+        item should be equalTo Item(ItemId("test"), customs = Map("foo"->"bar", "aaa"->"bbb"))
       }
 
       "with all fields" in new ThisScope {
@@ -361,7 +361,7 @@ class JsonFormatSpec extends Specification {
             valid => valid
           )
 
-        item should be equalTo Item("test", Set("one", "two", "three"), active = false, Some(Location(12.34, 5.67)), Some(new DateTime(123456789L)), Some(new DateTime(123456790L)), Some(321.67), Some(123.67), Map("foo"->"bar", "aaa"->"bbb"))
+        item should be equalTo Item(ItemId("test"), Set("one", "two", "three"), active = false, Some(Location(12.34, 5.67)), Some(new DateTime(123456789L)), Some(new DateTime(123456790L)), Some(321.67), Some(123.67), Map("foo"->"bar", "aaa"->"bbb"))
       }
     }
   }
@@ -373,7 +373,7 @@ class JsonFormatSpec extends Specification {
         import jsonFormat._
 
         val json = Json.toJson(Item(
-          iid = "test",
+          iid = ItemId("test"),
           types = Set("foo", "bar"),
           active = false,
           location = Some(Location(12.3, 45.6)),
@@ -404,12 +404,12 @@ class JsonFormatSpec extends Specification {
 
         import jsonFormat._
 
-        val json = Json.toJson(Action("jhon","apple", "eat", Some(9), Some(Location(9.8, 34.8)), Some(new DateTime(2013, 6, 23,12,30)), Map("foo"->"bar")))
+        val json = Json.toJson(Action(UserId("jhon"),ItemId("apple"), U2IAction.Like, Some(9), Some(Location(9.8, 34.8)), Some(new DateTime(2013, 6, 23,12,30)), Map("foo"->"bar")))
 
         (json \ "pio_appkey").validate[String] should be equalTo JsSuccess(appKey)
         (json \ "pio_uid").validate[String] should be equalTo JsSuccess("jhon")
         (json \ "pio_iid").validate[String] should be equalTo JsSuccess("apple")
-        (json \ "pio_action").validate[String] should be equalTo JsSuccess("eat")
+        (json \ "pio_action").validate[String] should be equalTo JsSuccess("like")
         (json \ "pio_rate").validate[Int] should be equalTo JsSuccess(9)
         (json \ "pio_latlng").validate[String] should be equalTo JsSuccess("34.8,9.8")
         (json \ "pio_t").validate[DateTime] should be equalTo JsSuccess(new DateTime(2013, 6, 23,12,30))


### PR DESCRIPTION
I like the fact that we now have types to represent the domain ( user, item, action, location ), it would be nice to go one step further and create marker types for the the Ids: 
This commit creates UserId and ItemId value classes to wrap the strings and uses them to describe the correct type in the various APIs.

The user to items actions are limited in predictionIO, this is now represented by the type U2IAction which encodes the possible values at the moment. For now I have used a sealed trait (since this can not be extended) Once predictionio supports custom types we will be able to remove the sealed restriction. At that point it is possible that a custom method to create an implicit json format which takes into account the custom actions will have to be defined.

I added the appropriate json transformations to keep the json serialization identical.
