### PR TITLE
Enforce immutable collections in API

### DIFF
--- a/src/main/scala/com/github/filosganga/play/predictionio/Api.scala
+++ b/src/main/scala/com/github/filosganga/play/predictionio/Api.scala
@@ -1,7 +1,9 @@
-package com.github.filosganga.play.predictionio
+package com.github.filosganga.play
+package predictionio
 
 
 import scala.concurrent._
+import scala.collection.immutable
 import play.api.libs.ws.WS
 import play.api.libs.json._
 
@@ -92,7 +94,7 @@ trait Api {
                       attributes: Set[String] = Set.empty,
                       location: Option[Location] = None,
                       distance: Option[Distance] = None)
-                     (implicit ec: ExecutionContext): Future[Iterable[ItemInfo]] = {
+                     (implicit ec: ExecutionContext): Future[immutable.Seq[ItemInfo]] = {
 
     import format._
 
@@ -112,7 +114,7 @@ trait Api {
 
     WS.url(s"$endpoint/engines/itemrec/$engine/topn.json").withQueryString(parameters: _*).get().flatMap {
       case response if response.status >= 300 => Future.failed(new RuntimeException(response.statusText))
-      case response => Json.fromJson[Iterable[ItemInfo]](response.json).fold(invalid => Future.failed(new RuntimeException), Future.successful)
+      case response => Json.fromJson[immutable.Seq[ItemInfo]](response.json).fold(invalid => Future.failed(new RuntimeException), Future.successful)
     }
   }
 
@@ -123,7 +125,7 @@ trait Api {
                       attributes: Set[String] = Set.empty,
                       location: Option[Location] = None,
                       distance: Option[Distance] = None)
-                     (implicit ec: ExecutionContext): Future[Iterable[ItemInfo]] = {
+                     (implicit ec: ExecutionContext): Future[immutable.Seq[ItemInfo]] = {
 
     import format._
 
@@ -143,7 +145,7 @@ trait Api {
 
     WS.url(s"$endpoint/engines/itemsim/$engine/topn.json").withQueryString(parameters: _*).get().flatMap {
       case response if response.status >= 300 => Future.failed(new RuntimeException(response.statusText))
-      case response => Json.fromJson[Iterable[ItemInfo]](response.json).fold(invalid => Future.failed(new RuntimeException), Future.successful)
+      case response => Json.fromJson[immutable.Seq[ItemInfo]](response.json).fold(invalid => Future.failed(new RuntimeException), Future.successful)
     }
   }
 

--- a/src/main/scala/com/github/filosganga/play/predictionio/PredictionIO.scala
+++ b/src/main/scala/com/github/filosganga/play/predictionio/PredictionIO.scala
@@ -23,7 +23,7 @@ import play.api.Application
 
 import org.joda.time.DateTime
 import scala.concurrent.{ExecutionContext, Future}
-
+import scala.collection.immutable
 /**
  *
  * @author Filippo De Luca - me@filippodeluca.com
@@ -102,7 +102,7 @@ object PredictionIO {
                           types: Set[String] = Set.empty,
                           attributes: Set[String] = Set.empty,
                           location: Option[Location],
-                          distance: Option[Distance])(implicit app: Application, ec: ExecutionContext): Future[Iterable[ItemInfo]] = {
+                          distance: Option[Distance])(implicit app: Application, ec: ExecutionContext): Future[immutable.Seq[ItemInfo]] = {
 
     api.getItemsRecTopN(engine, userId, n, types, attributes, location, distance)
   }
@@ -113,7 +113,7 @@ object PredictionIO {
                           types: Set[String] = Set.empty,
                           attributes: Set[String] = Set.empty,
                           location: Option[Location],
-                          distance: Option[Distance])(implicit app: Application, ec: ExecutionContext): Future[Iterable[ItemInfo]] = {
+                          distance: Option[Distance])(implicit app: Application, ec: ExecutionContext): Future[immutable.Seq[ItemInfo]] = {
 
     api.getItemsSimTopN(engine, targetId, n, types, attributes, location, distance)
   }
@@ -124,7 +124,7 @@ object PredictionIO {
                       types: Set[String] = Set.empty,
                       attributes: Set[String] = Set.empty,
                       location: Option[Location],
-                      distance: Option[Distance])(implicit app: Application, ec: ExecutionContext): Future[Iterable[Item]] = {
+                      distance: Option[Distance])(implicit app: Application, ec: ExecutionContext): Future[immutable.Seq[Item]] = {
 
     getItemsInfoRecTopN(engine, userId, n, types, attributes, location, distance).flatMap {
       xs => Future.sequence(xs.map(x => getItem(x.id)))
@@ -137,7 +137,7 @@ object PredictionIO {
                       types: Set[String] = Set.empty,
                       attributes: Set[String] = Set.empty,
                       location: Option[Location],
-                      distance: Option[Distance])(implicit app: Application, ec: ExecutionContext): Future[Iterable[Item]] = {
+                      distance: Option[Distance])(implicit app: Application, ec: ExecutionContext): Future[immutable.Seq[Item]] = {
 
     getItemsInfoSimTopN(engine, targetId, n, types, attributes, location, distance).flatMap {
       xs => Future.sequence(xs.map(x => getItem(x.id)))


### PR DESCRIPTION
This commit is orthogonal to the types commit and proposes to enforce using immutable collections in the return types of the API
