### PR TITLE
Add specialized exceptions to the API

### DIFF
--- a/src/main/scala/com/github/filosganga/play/predictionio/package.scala
+++ b/src/main/scala/com/github/filosganga/play/predictionio/package.scala
@@ -27,6 +27,16 @@ package com.github.filosganga.play
  */
 package object predictionio {
 
+  trait PredictionIOException {
+    val message = ""
+    val cause: Throwable = null
+  }
 
+  case class NoRecommendationException(override val message: String, override val cause: Throwable = null) extends Exception(message, cause, true, false) with PredictionIOException
+
+  case class PredictionIOServerException(override val message: String, override val cause: Throwable = null) extends Exception(message, cause, true, false) with PredictionIOException
+
+  case class PredictionIOClientException(override val message: String, override val cause: Throwable = null) extends Exception(message, cause, true, false) with PredictionIOException
 
 }
+


### PR DESCRIPTION
Three custom exceptions to replace the  raw RuntimeException : 
- `NoRecommendationException` when the server returns a 404 about not having recommendations
- `PredictionIOServerException` when the server encounters an internal server error (5xx HTTP status code)
- `PredictionIOClientException` for other unknown cases

I have removed the 3xx HTTP status code handling for now and intend to allow the http client to follow through redirections at least for 302, 303 and 307 it makes sense 304 should never happen though. Since I wasn't sure about the correct handling I did something simple to be improved upon.
