### PR TITLE
Properly read prediction results

### DIFF
--- a/src/main/scala/com/github/filosganga/play/predictionio/ItemInfo.scala
+++ b/src/main/scala/com/github/filosganga/play/predictionio/ItemInfo.scala
@@ -4,4 +4,4 @@ package com.github.filosganga.play.predictionio
  *
  * @author Filippo De Luca - me@filippodeluca.com
  */
-case class ItemInfo(id: String, attributes: Set[String])
+case class ItemInfo(id: ItemId, attributes: Map[String,String]=Map())

--- a/src/main/scala/com/github/filosganga/play/predictionio/PredictionIO.scala
+++ b/src/main/scala/com/github/filosganga/play/predictionio/PredictionIO.scala
@@ -127,7 +127,7 @@ object PredictionIO {
                       distance: Option[Distance])(implicit app: Application, ec: ExecutionContext): Future[immutable.Seq[Item]] = {
 
     getItemsInfoRecTopN(engine, userId, n, types, attributes, location, distance).flatMap {
-      xs => Future.sequence(xs.map(x => getItem(ItemId(x.id))))
+      xs => Future.sequence(xs.map(x => getItem(x.id)))
     }
   }
 
@@ -140,7 +140,7 @@ object PredictionIO {
                       distance: Option[Distance])(implicit app: Application, ec: ExecutionContext): Future[immutable.Seq[Item]] = {
 
     getItemsInfoSimTopN(engine, targetId, n, types, attributes, location, distance).flatMap {
-      xs => Future.sequence(xs.map(x => getItem(ItemId(x.id))))
+      xs => Future.sequence(xs.map(x => getItem(x.id)))
     }
   }
 

--- a/src/test/scala/com/github/filosganga/play/predictionio/JsonFormatSpec.scala
+++ b/src/test/scala/com/github/filosganga/play/predictionio/JsonFormatSpec.scala
@@ -19,10 +19,11 @@
 
 package com.github.filosganga.play.predictionio
 
-import play.api.libs.json.{JsSuccess, Json}
+import play.api.libs.json._
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 import org.joda.time.DateTime
+import scala.collection.immutable
 
 
 /**
@@ -418,6 +419,29 @@ class JsonFormatSpec extends Specification {
     }
   }
 
+  "predictionRead" should{
+    "be able to read a prediction result in a Seq[ItemInfo]" in new ThisScope{
+      import jsonFormat.predictionRead
+      val json=Json.parse(
+        """
+          |{
+          |  "pio_iids": [
+          |  "52d970c46c00006b004ac6d3",
+          |  "52de8270c30000c200c21fd3"
+          |  ],
+          |  "name": [
+          |  "foo",
+          |  "bar"
+          |  ]
+          |}
+        """.stripMargin)
+      val items=List(
+        ItemInfo(ItemId("52d970c46c00006b004ac6d3"), Map("name"->"foo")),
+        ItemInfo(ItemId("52de8270c30000c200c21fd3"), Map("name"->"bar"))
+      )
+      json.validate[immutable.Seq[ItemInfo]](predictionRead) === JsSuccess(items)
+    }
+  }
 
   trait ThisScope extends Scope {
 


### PR DESCRIPTION
ItemInfo structure doesn't match that of the returned results when asking for predictions in predictionio. This commit changes the structure of ItemInfo to both be closer to the predictionIO results yet be easier to use than these results. The custom json read takes care of the mapping.
